### PR TITLE
feat: add support for storing full blocks in walrus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ contrib/bitcoind-data
 contrib/fork-*
 e2e-bitcoin-spv.yml
 bitcoin-spv
+!cmd/bitcoin-spv/

--- a/bitcoinspv/bootstrap.go
+++ b/bitcoinspv/bootstrap.go
@@ -146,7 +146,7 @@ func (r *Relayer) initializeBTCCache(ctx context.Context) error {
 	// submitting headers from the light clients height - confirmationDepth (usually 6).
 	baseHeight := blockHeight - r.btcConfirmationDepth + 1
 
-	r.logger.Info().Msg("Fetching blocks/headers for cache and Walrus storage...")
+	r.logger.Info().Msg("Fetching blocks to internal cache and sending to Walrus storage...")
 	fetchFullBlocks := r.Config.StoreBlocksInWalrus && r.walrusHandler != nil
 	blocks, err := r.btcClient.GetBTCTailBlocksByHeight(baseHeight, fetchFullBlocks)
 	if err != nil {

--- a/bitcoinspv/bootstrap.go
+++ b/bitcoinspv/bootstrap.go
@@ -1,7 +1,6 @@
 package bitcoinspv
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -157,23 +156,7 @@ func (r *Relayer) initializeBTCCache(ctx context.Context) error {
 	if fetchFullBlocks {
 		r.logger.Info().Msgf("Attempting to store %d blocks to Walrus", len(blocks))
 		for _, ib := range blocks {
-			if ib.RawMsgBlock != nil {
-				var blockBuffer bytes.Buffer
-				if err := ib.RawMsgBlock.Serialize(&blockBuffer); err != nil {
-					r.logger.Error().Err(err).Msgf(
-						"failed to serialize block %d (%s) for Walrus",
-						ib.BlockHeight, ib.BlockHash().String(),
-					)
-					continue
-				}
-				_, walrusErr := r.walrusHandler.StoreBlock(blockBuffer.Bytes(), ib.BlockHeight, ib.BlockHash().String())
-				if walrusErr != nil {
-					r.logger.Warn().Err(walrusErr).Msgf(
-						"Walrus store failed for block %d (%s), continuing bootstrap.",
-						ib.BlockHeight, ib.BlockHash().String(),
-					)
-				}
-			}
+			r.UploadToWalrus(ib.RawMsgBlock, ib.BlockHeight, ib.BlockHash().String())
 		}
 	}
 

--- a/bitcoinspv/bootstrap.go
+++ b/bitcoinspv/bootstrap.go
@@ -146,14 +146,8 @@ func (r *Relayer) initializeBTCCache(ctx context.Context) error {
 	// submitting headers from the light clients height - confirmationDepth (usually 6).
 	baseHeight := blockHeight - r.btcConfirmationDepth + 1
 
-	// NOTE: here we are fetching only headers, if we want to fetch full blocks change the flag to true
+	r.logger.Info().Msg("Fetching blocks/headers for cache and Walrus storage...")
 	fetchFullBlocks := r.Config.StoreBlocksInWalrus && r.walrusHandler != nil
-
-	if fetchFullBlocks {
-		r.logger.Info().Msg("Fetching FULL BLOCKS for cache and Walrus storage...")
-	} else {
-		r.logger.Info().Msg("Fetching HEADERS ONLY for cache...")
-	}
 	blocks, err := r.btcClient.GetBTCTailBlocksByHeight(baseHeight, fetchFullBlocks)
 	if err != nil {
 		return fmt.Errorf("failed to get blocks/headers: %w", err)
@@ -161,7 +155,7 @@ func (r *Relayer) initializeBTCCache(ctx context.Context) error {
 
 	// Store full blocks in Walrus
 	if fetchFullBlocks {
-		r.logger.Info().Msgf("Attempting to store %d full blocks to Walrus", len(blocks))
+		r.logger.Info().Msgf("Attempting to store %d blocks to Walrus", len(blocks))
 		for _, ib := range blocks {
 			if ib.RawMsgBlock != nil {
 				var blockBuffer bytes.Buffer

--- a/bitcoinspv/clients/btcwrapper/query.go
+++ b/bitcoinspv/clients/btcwrapper/query.go
@@ -86,7 +86,7 @@ func (c *Client) GetBTCBlockByHash(
 
 	btcTxs := relayertypes.GetWrappedTxs(blockDataRes.block)
 	return relayertypes.NewIndexedBlock(
-		blockInfoRes.info.Height, &blockDataRes.block.Header, btcTxs,
+		blockInfoRes.info.Height, &blockDataRes.block.Header, btcTxs, blockDataRes.block,
 	), blockDataRes.block, nil
 }
 
@@ -203,7 +203,7 @@ func (c *Client) GetBTCTailBlocksByHeight(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get block header at height %d: %w", height, err)
 			}
-			indexedBlock = relayertypes.NewIndexedBlock(height, header, []*btcutil.Tx{})
+			indexedBlock = relayertypes.NewIndexedBlock(height, header, []*btcutil.Tx{}, nil)
 		}
 
 		blocks = append(blocks, indexedBlock)

--- a/bitcoinspv/clients/btcwrapper/zmq/subscribe.go
+++ b/bitcoinspv/clients/btcwrapper/zmq/subscribe.go
@@ -198,7 +198,7 @@ func (c *Client) getBlockByHash(
 	}
 
 	btcTxs := relayertypes.GetWrappedTxs(block)
-	indexedBlock := relayertypes.NewIndexedBlock(blockVerbose.Height, &block.Header, btcTxs)
+	indexedBlock := relayertypes.NewIndexedBlock(blockVerbose.Height, &block.Header, btcTxs, block)
 
 	return indexedBlock, nil
 }

--- a/bitcoinspv/config/relayer.go
+++ b/bitcoinspv/config/relayer.go
@@ -17,6 +17,8 @@ const (
 )
 
 // RelayerConfig defines configuration for the spv relayer.
+//
+//nolint:govet
 type RelayerConfig struct {
 	// Format is the format of the log (json|auto|console|logfmt)
 	Format string `mapstructure:"log-format"`

--- a/bitcoinspv/config/relayer.go
+++ b/bitcoinspv/config/relayer.go
@@ -37,6 +37,12 @@ type RelayerConfig struct {
 	HeadersChunkSize uint32 `mapstructure:"headers-chunk-size"`
 	// ProcessBlockTimeout is the timeout duration for processing a single block.
 	ProcessBlockTimeout time.Duration `mapstructure:"process-block-timeout"`
+
+	// Walrus config
+	StoreBlocksInWalrus  bool     `mapstructure:"store-in-walrus"`
+	WalrusStorageEpochs  int      `mapstructure:"walrus-storage-epochs"`
+	WalrusPublisherURLs  []string `mapstructure:"walrus-publisher-urls"`
+	WalrusAggregatorURLs []string `mapstructure:"walrus-aggregator-urls"`
 }
 
 func isPresent(v string, list []string) bool {
@@ -130,5 +136,9 @@ func DefaultRelayerConfig() RelayerConfig {
 		BTCCacheSize:          minBTCCacheSize,
 		HeadersChunkSize:      minheadersChunkSize,
 		BTCConfirmationDepth:  defaultConfirmationDepth,
+		StoreBlocksInWalrus:   false,
+		WalrusPublisherURLs:   []string{},
+		WalrusAggregatorURLs:  []string{},
+		WalrusStorageEpochs:   1,
 	}
 }

--- a/bitcoinspv/relayer.go
+++ b/bitcoinspv/relayer.go
@@ -22,6 +22,9 @@ type Relayer struct {
 	btcClient clients.BTCClient
 	lcClient  clients.BitcoinSPV
 
+	// Walrus
+	walrusHandler *WalrusHandler
+
 	// Cache and state
 	btcCache             *types.BTCCache
 	btcConfirmationDepth int64
@@ -36,18 +39,20 @@ type Relayer struct {
 
 // New creates and returns a new relayer object
 func New(
-	config *config.RelayerConfig,
+	cfg *config.RelayerConfig,
 	parentLogger zerolog.Logger,
 	btcClient clients.BTCClient,
 	lcClient clients.BitcoinSPV,
+	walrusHandler *WalrusHandler,
 ) (*Relayer, error) {
 	logger := parentLogger.With().Str("module", "bitcoinspv").Logger()
 	relayer := &Relayer{
-		Config:               config,
+		Config:               cfg,
 		logger:               logger,
 		btcClient:            btcClient,
 		lcClient:             lcClient,
-		btcConfirmationDepth: config.BTCConfirmationDepth,
+		walrusHandler:        walrusHandler,
+		btcConfirmationDepth: cfg.BTCConfirmationDepth,
 		quitChannel:          make(chan struct{}),
 		isStarted:            false,
 		catchupLoopWait:      10 * time.Second,

--- a/bitcoinspv/relayer_test.go
+++ b/bitcoinspv/relayer_test.go
@@ -42,6 +42,7 @@ func setupTest(t *testing.T) (*Relayer, *mocks.MockBTCClient, *mocks.MockBitcoin
 		logger,
 		btcClient,
 		lcClient,
+		nil,
 	)
 	relayer.catchupLoopWait = 10 * time.Millisecond
 

--- a/bitcoinspv/types/indexed_block.go
+++ b/bitcoinspv/types/indexed_block.go
@@ -12,6 +12,7 @@ type IndexedBlock struct {
 	BlockHeader  *wire.BlockHeader
 	Transactions []*btcutil.Tx
 	BlockHeight  int64
+	RawMsgBlock  *wire.MsgBlock
 }
 
 // NewIndexedBlock creates a new IndexedBlock instance with the given block height,
@@ -20,11 +21,13 @@ func NewIndexedBlock(
 	blockHeight int64,
 	blockHeader *wire.BlockHeader,
 	transactions []*btcutil.Tx,
+	rawMsgBlock *wire.MsgBlock,
 ) *IndexedBlock {
 	return &IndexedBlock{
 		BlockHeight:  blockHeight,
 		BlockHeader:  blockHeader,
 		Transactions: transactions,
+		RawMsgBlock:  rawMsgBlock,
 	}
 }
 

--- a/bitcoinspv/types/indexed_block.go
+++ b/bitcoinspv/types/indexed_block.go
@@ -10,9 +10,9 @@ import (
 // and transaction details needed for Merkle proof generation
 type IndexedBlock struct {
 	BlockHeader  *wire.BlockHeader
+	RawMsgBlock  *wire.MsgBlock
 	Transactions []*btcutil.Tx
 	BlockHeight  int64
-	RawMsgBlock  *wire.MsgBlock
 }
 
 // NewIndexedBlock creates a new IndexedBlock instance with the given block height,

--- a/bitcoinspv/walrus_handler.go
+++ b/bitcoinspv/walrus_handler.go
@@ -1,0 +1,85 @@
+package bitcoinspv
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/gonative-cc/relayer/bitcoinspv/config"
+	walrus "github.com/namihq/walrus-go"
+	"github.com/rs/zerolog"
+)
+
+// WalrusHandler wraps the Walrus client
+type WalrusHandler struct {
+	client *walrus.Client
+	logger zerolog.Logger
+	config *config.RelayerConfig
+}
+
+// NewWalrusHandler creates and initializes a new WalrusHandler, nil if not enabled
+func NewWalrusHandler(cfg *config.RelayerConfig, parentLogger zerolog.Logger) (*WalrusHandler, error) {
+	if !cfg.StoreBlocksInWalrus {
+		return nil, nil
+	}
+
+	logger := parentLogger.With().Str("module", "bitcoinspv/walrus_handler").Logger()
+	logger.Info().Msg("Initializing Walrus client...")
+
+	opts := []walrus.ClientOption{}
+	if len(cfg.WalrusPublisherURLs) > 0 {
+		opts = append(opts, walrus.WithPublisherURLs(cfg.WalrusPublisherURLs))
+	}
+	if len(cfg.WalrusAggregatorURLs) > 0 {
+		opts = append(opts, walrus.WithAggregatorURLs(cfg.WalrusAggregatorURLs))
+	}
+
+	walrusClient := walrus.NewClient(opts...)
+	if walrusClient == nil {
+		return nil, fmt.Errorf("failed to init Walrus")
+	}
+
+	logger.Info().Msg("Walrus client init successfull")
+	return &WalrusHandler{
+		client: walrusClient,
+		logger: logger,
+		config: cfg,
+	}, nil
+}
+
+// StoreBlock attempts to store the raw block data in Walrus.
+func (wh *WalrusHandler) StoreBlock(
+	rawBlockData []byte,
+	blockHeight int64,
+	blockHashStr string,
+) (*string, error) {
+	rawBlockHex := hex.EncodeToString(rawBlockData)
+	// only for debug (block can be very long)
+	wh.logger.Debug().Msgf("Storing block: {\n heigh:%d,\n hash:%s,\n raw_block:%s\n} in Walrus...", blockHeight, blockHashStr, rawBlockHex)
+
+	epochs := wh.config.WalrusStorageEpochs
+	storeOpts := &walrus.StoreOptions{Epochs: epochs}
+
+	resp, err := wh.client.Store(rawBlockData, storeOpts)
+	if err != nil {
+		wh.logger.Error().Err(err).Msgf("Failed to store block %d (%s) in Walrus", blockHeight, blockHashStr)
+		return nil, err
+	}
+
+	var blobID string
+	if resp.NewlyCreated != nil {
+		blobID = resp.NewlyCreated.BlobObject.BlobID
+		wh.logger.Info().Msgf(
+			"Block %d (%s) newly stored in Walrus. Blob ID: %s, Cost: %d",
+			blockHeight, blockHashStr, blobID, resp.NewlyCreated.Cost,
+		)
+	} else if resp.AlreadyCertified != nil {
+		blobID = resp.AlreadyCertified.BlobID
+		wh.logger.Info().Msgf(
+			"Block %d (%s) data already stored in Walrus. Blob ID: %s, End Epoch: %d",
+			blockHeight, blockHashStr, blobID, resp.AlreadyCertified.EndEpoch,
+		)
+	} else {
+		return nil, fmt.Errorf("unexpected Walrus store response for block %d (%s)", blockHeight, blockHashStr)
+	}
+	return &blobID, nil
+}

--- a/bitcoinspv/walrus_handler.go
+++ b/bitcoinspv/walrus_handler.go
@@ -54,7 +54,7 @@ func (wh *WalrusHandler) StoreBlock(
 ) (*string, error) {
 	rawBlockHex := hex.EncodeToString(rawBlockData)
 	// only for debug (block can be very long)
-	wh.logger.Debug().Msgf("Storing block: {\n heigh:%d,\n hash:%s,\n raw_block:%s\n} in Walrus...", 
+	wh.logger.Debug().Msgf("Storing block: {\n heigh:%d,\n hash:%s,\n raw_block:%s\n} in Walrus...",
 		blockHeight, blockHashStr, rawBlockHex)
 
 	epochs := wh.config.WalrusStorageEpochs
@@ -67,19 +67,20 @@ func (wh *WalrusHandler) StoreBlock(
 	}
 
 	var blobID string
-	if resp.NewlyCreated != nil {
+	switch {
+	case resp.NewlyCreated != nil:
 		blobID = resp.NewlyCreated.BlobObject.BlobID
 		wh.logger.Info().Msgf(
 			"Block %d (%s) newly stored in Walrus. Blob ID: %s, Cost: %d",
 			blockHeight, blockHashStr, blobID, resp.NewlyCreated.Cost,
 		)
-	} else if resp.AlreadyCertified != nil {
+	case resp.AlreadyCertified != nil:
 		blobID = resp.AlreadyCertified.BlobID
 		wh.logger.Info().Msgf(
 			"Block %d (%s) data already stored in Walrus. Blob ID: %s, End Epoch: %d",
 			blockHeight, blockHashStr, blobID, resp.AlreadyCertified.EndEpoch,
 		)
-	} else {
+	default:
 		return nil, fmt.Errorf("unexpected Walrus store response for block %d (%s)", blockHeight, blockHashStr)
 	}
 	return &blobID, nil

--- a/bitcoinspv/walrus_handler.go
+++ b/bitcoinspv/walrus_handler.go
@@ -38,7 +38,7 @@ func NewWalrusHandler(cfg *config.RelayerConfig, parentLogger zerolog.Logger) (*
 		return nil, fmt.Errorf("failed to init Walrus")
 	}
 
-	logger.Info().Msg("Walrus client init successfull")
+	logger.Info().Msg("Walrus client init successful")
 	return &WalrusHandler{
 		client: walrusClient,
 		logger: logger,
@@ -54,7 +54,8 @@ func (wh *WalrusHandler) StoreBlock(
 ) (*string, error) {
 	rawBlockHex := hex.EncodeToString(rawBlockData)
 	// only for debug (block can be very long)
-	wh.logger.Debug().Msgf("Storing block: {\n heigh:%d,\n hash:%s,\n raw_block:%s\n} in Walrus...", blockHeight, blockHashStr, rawBlockHex)
+	wh.logger.Debug().Msgf("Storing block: {\n heigh:%d,\n hash:%s,\n raw_block:%s\n} in Walrus...", 
+		blockHeight, blockHashStr, rawBlockHex)
 
 	epochs := wh.config.WalrusStorageEpochs
 	storeOpts := &walrus.StoreOptions{Epochs: epochs}

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
+	github.com/namihq/walrus-go v0.2.0
 	github.com/pebbe/zmq4 v1.4.0
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
+github.com/namihq/walrus-go v0.2.0 h1:nYLqg3s4Lnzh6aYyk/8avemIWCT7xHRX7RMimcIqxHg=
+github.com/namihq/walrus-go v0.2.0/go.mod h1:/SzxtwOaLtZtHtdrFlB4mFITAZjPMJE0pOjWzv6A1VY=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Tested locally, everything works when starting the bitcoin-spv-relayer with `--walrus` flag

Closes: #244 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Add optional full block storage in Walrus for the Bitcoin SPV relayer

New Features:
- Introduce a --walrus CLI flag and RelayerConfig options to enable full block storage in Walrus
- Implement a WalrusHandler for uploading serialized blocks with configurable epochs and endpoints
- Fetch and persist raw Bitcoin blocks during bootstrap and on new block events when enabled

Enhancements:
- Extend IndexedBlock and BTC client wrappers to carry raw MsgBlock data for storage

Build:
- Add github.com/namihq/walrus-go dependency to go.mod