### PR TITLE
fix: add proper error handling for sui.getObject()

### DIFF
--- a/bitcoinspv/clients/sui/sui_spv_client.go
+++ b/bitcoinspv/clients/sui/sui_spv_client.go
@@ -70,13 +70,25 @@ func New(
 			ShowOwner: true,
 		},
 	})
+
 	if err != nil {
 		return nil, err
 	}
 
-	if lcObjectResp.Data.Owner.Shared == nil {
-		return nil, fmt.Errorf("error init spv client")
+	if lcObjectResp.Error != nil {
+		if lcObjectResp.Error.Data.NotExists != nil {
+			return nil, fmt.Errorf("object '%s' does not exist", lightClientObjectIDHex)
+		}
+		if lcObjectResp.Error.Data.Deleted != nil {
+			return nil, fmt.Errorf("object '%s' has been deleted", lightClientObjectIDHex)
+		}
+		return nil, fmt.Errorf("error fetching object '%s': %v", lightClientObjectIDHex, lcObjectResp.Error)
 	}
+
+	if lcObjectResp.Data.Owner.Shared == nil {
+		return nil, fmt.Errorf("object '%s' is not a shared object and cannot be used for the light client", lightClientObjectIDHex)
+	}
+
 	lcObjArg := suiptb.CallArg{
 		Object: &suiptb.ObjectArg{
 			SharedObject: &suiptb.SharedObjectArg{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

There was a segmentation error happening when the lc_object_id did not exist on chain. Similarly to other sui SDK the err returned from call only tells us whether the call itself was successful, in order to know what was actually the result of the operation we need to inspect the error field from the response body. This PR adds proper error inspection that will help avoid such problems in the future 

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

