### PR TITLE
feat: use msg pack api from workers

### DIFF
--- a/bitcoinspv/clients/btcindexer/client.go
+++ b/bitcoinspv/clients/btcindexer/client.go
@@ -3,16 +3,14 @@ package btcindexer
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math/rand"
-	"net/http"
 	"time"
 
 	"github.com/gonative-cc/relayer/bitcoinspv/types"
+	"github.com/gonative-cc/workers/api/btcindexer"
 	"github.com/rs/zerolog"
 )
 
@@ -23,25 +21,18 @@ const (
 	maxBackoff     = 8 * time.Second
 )
 
-// Payload is structure that the indexer expects.
-type Payload struct {
-	RawBlockHex string `json:"rawBlockHex"`
-	Height      int64  `json:"height"`
-}
-
 // Client is a client for communicating with the nBTC indexer worker.
+// It wraps the btcindexer API client to add retry logic.
 type Client struct {
-	logger zerolog.Logger
-	client *http.Client
-	url    string
+	logger    zerolog.Logger
+	apiClient btcindexer.Client
 }
 
 // NewClient creates a new client for the indexer.
 func NewClient(url string, parentLogger zerolog.Logger) *Client {
 	return &Client{
-		url:    fmt.Sprintf("%s/bitcoin/blocks", url),
-		client: &http.Client{Timeout: 10 * time.Second},
-		logger: parentLogger.With().Str("module", "btcindexer_client").Logger(),
+		logger:    parentLogger.With().Str("module", "btcindexer_client").Logger(),
+		apiClient: btcindexer.NewClient(url),
 	}
 }
 
@@ -49,14 +40,14 @@ func NewClient(url string, parentLogger zerolog.Logger) *Client {
 // TODO: this should not block the main process
 // probably we should use CF queues
 func (c *Client) SendBlocks(ctx context.Context, blocks []*types.IndexedBlock) error {
-	if c == nil || c.client == nil {
+	if c == nil {
 		return errors.New("btcindexer.Client is not initialized")
 	}
 	if len(blocks) == 0 {
 		return nil
 	}
 
-	jsonData, err := c.preparePayload(blocks)
+	payload, err := c.preparePayload(blocks)
 	if err != nil {
 		return err
 	}
@@ -67,7 +58,7 @@ func (c *Client) SendBlocks(ctx context.Context, blocks []*types.IndexedBlock) e
 			return ctx.Err()
 		}
 
-		shouldRetry, err := c.sendAndHandleResponse(ctx, jsonData)
+		shouldRetry, err := c.sendAndHandleResponse(payload)
 		if err != nil {
 			// Non-retryable
 			return err
@@ -86,14 +77,8 @@ func (c *Client) SendBlocks(ctx context.Context, blocks []*types.IndexedBlock) e
 	return fmt.Errorf("failed to send blocks to indexer after %d attempts: %w", maxRetries+1, lastErr)
 }
 
-func (c *Client) sendAndHandleResponse(ctx context.Context, payload []byte) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url, bytes.NewReader(payload))
-	if err != nil {
-		return false, fmt.Errorf("failed to create indexer request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.client.Do(req)
+func (c *Client) sendAndHandleResponse(payload btcindexer.PutBlocksReq) (bool, error) {
+	resp, err := c.apiClient.PutBlocks(payload)
 	if err != nil {
 		return true, err
 	}
@@ -118,19 +103,19 @@ func (c *Client) sendAndHandleResponse(ctx context.Context, payload []byte) (boo
 	return true, fmt.Errorf("indexer returned unhandled status: %d", resp.StatusCode)
 }
 
-func (c *Client) preparePayload(blocks []*types.IndexedBlock) ([]byte, error) {
-	payload := make([]Payload, len(blocks))
+func (c *Client) preparePayload(blocks []*types.IndexedBlock) (btcindexer.PutBlocksReq, error) {
+	putBlocksReq := make(btcindexer.PutBlocksReq, len(blocks))
 	for i, block := range blocks {
 		var blockBuffer bytes.Buffer
 		if err := block.MsgBlock.Serialize(&blockBuffer); err != nil {
 			return nil, fmt.Errorf("failed to serialize block %d: %w", block.BlockHeight, err)
 		}
-		payload[i] = Payload{
-			Height:      block.BlockHeight,
-			RawBlockHex: hex.EncodeToString(blockBuffer.Bytes()),
+		putBlocksReq[i] = btcindexer.PutBlock{
+			Height: block.BlockHeight,
+			Block:  blockBuffer.Bytes(),
 		}
 	}
-	return json.Marshal(payload)
+	return putBlocksReq, nil
 }
 
 func (c *Client) backoff(ctx context.Context, attempt int) {

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,15 @@
 module github.com/gonative-cc/relayer
 
-go 1.23.4
+go 1.24.4
 
-toolchain go1.24.1
+toolchain go1.24.5
 
 require (
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/fardream/go-bcs v0.8.7
+	github.com/gonative-cc/workers/api/btcindexer v0.0.0-20250727190927-e10e7f2f70f8
 	github.com/joho/godotenv v1.5.1
 	github.com/pattonkan/sui-go v0.1.5
 	github.com/rs/zerolog v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gonative-cc/workers/api/btcindexer v0.0.0-20250727190927-e10e7f2f70f8 h1:GYG7tj+PBtNHT8zYg0vlfxIbYc/Nhz6SQkbvZBrXemU=
+github.com/gonative-cc/workers/api/btcindexer v0.0.0-20250727190927-e10e7f2f70f8/go.mod h1:JkLDY3PtTykV/ENOiPmbYV1naqBnmuXuC45EXelNBwo=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Use the msgpack-based workers/api/btcindexer client for block submissions, replacing custom HTTP and JSON logic while retaining retry behavior.

Enhancements:
- Replace manual HTTP client and JSON payload handling with the workers/api/btcindexer client and typed PutBlocksReq/PutBlock messages
- Remove custom Payload struct and eliminate JSON marshalling and raw HTTP request construction in SendBlocks
- Preserve existing retry logic while delegating block submission to apiClient.PutBlocks

Build:
- Bump Go version to 1.24.4 and toolchain to 1.24.5
- Add workers/api/btcindexer dependency